### PR TITLE
Use Esri Calcite, add Identify requests to get basins attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,55 +4,376 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
+    <!-- Bootstrap -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://js.arcgis.com/4.6/esri/css/main.css">
+    <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css?family=EB+Garamond" rel="stylesheet">
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.10/css/all.css" integrity="sha384-+d0P83n9kaQMCwj8F4RJB66tzIwOKmrdb46+porD/OvrJ+37WqIM7UoBtwHO6Nlg"
-       crossorigin="anonymous">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.10/css/all.css" integrity="sha384-+d0P83n9kaQMCwj8F4RJB66tzIwOKmrdb46+porD/OvrJ+37WqIM7UoBtwHO6Nlg" crossorigin="anonymous">
+    <!-- Calcite Maps Bootstrap -->
+    <link rel="stylesheet" href="https://esri.github.io/calcite-maps/dist/css/calcite-maps-bootstrap.min-v0.7.css">
+    <!-- Calcite Maps -->
+    <link rel="stylesheet" href="https://esri.github.io/calcite-maps/dist/css/calcite-maps-arcgis-4.x.min-v0.7.css">
+    <!-- ArcGIS JS 4 -->
+    <link rel="stylesheet" href="https://js.arcgis.com/4.7/esri/css/main.css">
+    <!-- Keep ours last to override the rest -->
     <link rel="stylesheet" href="main.css">
 
     <title>Welcome to iCreek</title>
   </head>
-  <body>
-
-    <!-- Heading section -->
-    <img src="assets/banner.png" class="img-fluid" alt="Responsive image" id="heading-img">
+  <body class="row calcite-maps calcite-nav-top">
 
     <div class="container">
-      <div class="row">
-        <div class="col-md">
-            <h1 class="display-3 text-center text-info main-heading">How Healthy is Your Water?</h1>
-            <div class="input-group mb-3">
-              <div class="input-group-prepend">
-                <span class="input-group-text" id="inputGroup-sizing-default">Address</span>
-              </div>
-              <input type="text" class="form-control" aria-label="Default" aria-describedby="inputGroup-sizing-default" id="AddressInput" required>
-              <div class="input-group-append">
-                <button class="btn btn-primary bg-info border-info" type="button" data-toggle="tooltip" data-placement="bottom" title="Search" onclick="getLatLongFromAddress();">
-                  <span><i class="fas fa-search"></i></span>
-                </button>
+      <img src="assets/banner.png" class="img-fluid" alt="Responsive image" id="heading-img">
 
-              </div>
-                <button class="btn btn-primary bg-info border-info" id="current-location-btn" type="button" data-toggle="tooltip" data-placement="bottom" title="Use current location" onclick="getAddressFromBrowserLocation();">
-                  <span><i class="fas fa-location-arrow"></i></span>
-                </button>
-            </div>
+      <div id="call-to-action" class="row" style="padding-bottom:1em; background: rgba(255, 255, 255, 0.75);">
+        <div class="col-md" align="center">
+          <h1 class="display-3 text-center main-heading">How Healthy is Your Water?</h1>
+          <!-- <div class="input-group mb-3"> -->
+          <!--   <div class="input-group-prepend"> -->
+          <!--     <span class="input-group-text" id="inputGroup-sizing-default">Address</span> -->
+          <!--   </div> -->
+          <!--   <input type="text" class="form-control" aria-label="Default" aria-describedby="inputGroup-sizing-default" id="AddressInput" required> -->
+          <!--   <div class="input-group-append"> -->
+          <!--     <button class="btn btn-primary bg-info border-info" type="button" data-toggle="tooltip" data-placement="bottom" title="Search" onclick="getLatLongFromAddress();"> -->
+          <!--       <span><i class="fas fa-search"></i></span> -->
+          <!--     </button> -->
+          <!--   </div> -->
+          <!--     <button class="btn btn-primary bg-info border-info" id="current-location-btn" type="button" data-toggle="tooltip" data-placement="bottom" title="Use current location" onclick="getAddressFromBrowserLocation();"> -->
+          <!--       <span><i class="fas fa-location-arrow"></i></span> -->
+          <!--     </button> -->
+          <!--   </div> -->
+          <!-- <div class="calcite-navbar-search"> -->
+          <div id="searchWidgetDiv"></div>
+          <!-- </div> -->
         </div>
       </div>
-      <div class="row">
-        <div class="col-md">
-          <div id="waterway-info"></div>
+
+      <div id="map" class="row">
+        <!-- Nav -->
+        <nav class="navbar calcite-navbar navbar-fixed-top calcite-text-dark calcite-bg-light" style="background: rgba(255, 246, 212, 0.99);">
+          <!-- Menu -->
+          <!-- <div class="dropdown calcite-dropdown calcite-text-dark calcite-bg-light" role="presentation"> -->
+            <!-- <a class="dropdown-toggle" role="menubutton" aria-haspopup="true" aria-expanded="false" tabindex="0"> -->
+            <!--   <div class="calcite-dropdown-toggle"> -->
+            <!--     <span class="sr-only">Toggle dropdown menu</span> -->
+            <!--     <span></span> -->
+            <!--     <span></span> -->
+            <!--     <span></span> -->
+            <!--     <span></span> -->
+            <!--   </div> -->
+            <!-- </a> -->
+            <!-- <ul class="dropdown-menu" role="menu"> -->
+            <!--   <li><a role="menuitem" tabindex="0" data-target="#panelInfo" aria-haspopup="true"><span class="glyphicon glyphicon-info-sign"></span> About</a></li> -->
+            <!--   <li><a role="menuitem" tabindex="0" href="#" data-target="#panelLegend" aria-haspopup="true"><span class="glyphicon glyphicon-list-alt"></span> Legend</a></li> -->
+            <!-- </ul> -->
+          <!-- </div> -->
+          <!-- Title -->
+          <div class="calcite-title calcite-overflow-hidden">
+            <!-- TODO: Remove the hacky &nbsp; -->
+            <span class="calcite-title-main">&nbsp; iCreek</span>
+            <span class="calcite-title-divider hidden-xs"></span>
+            <span class="calcite-title-sub hidden-xs">Brought to you by <em>Cumberland River Compact</em></span>
+          </div>
+        </nav>
+
+        <!-- Map -->
+        <div class="calcite-map calcite-map-absolute">
+          <div id="mapViewDiv"></div>
         </div>
-        <div class="col-md">
-            <div id="map"></div>
+
+        <!-- Panels -->
+        <div class="calcite-panels calcite-panels-left calcite-text-dark calcite-bg-light panel-group">
+
+          <!-- About Panel -->
+          <!-- <div id="panelInfo" class="panel collapse in"> -->
+          <!--   <div id="headingInfo" class="panel-heading" role="tab"> -->
+          <!--     <div class="panel-title"> -->
+          <!--       <a class="panel-toggle" role="button" data-toggle="collapse" href="#collapseInfo"  aria-expanded="true" aria-controls="collapseInfo"><span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span><span class="panel-label">About</span></a> -->
+          <!--       <a class="panel-close" role="button" data-toggle="collapse" tabindex="0" href="#panelInfo"><span class="esri-icon esri-icon-close" aria-hidden="true"></span></a> -->
+          <!--     </div> -->
+          <!--   </div> -->
+          <!--   <div id="collapseInfo" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingInfo"> -->
+          <!--     <div class="panel-body"> -->
+          <!--       <p>This is my map app!</p> -->
+          <!--     </div> -->
+          <!--   </div> -->
+          <!-- </div> -->
+
+          <!-- Legend Panel -->
+          <!-- <div id="panelLegend" class="panel collapse"> -->
+          <!--   <div id="headingLegend" class="panel-heading" role="tab"> -->
+          <!--     <div class="panel-title"> -->
+          <!--       <a class="panel-toggle" role="button" data-toggle="collapse" href="#collapseLegend" aria-expanded="false" aria-controls="collapseLegend"><span class="glyphicon glyphicon-list-alt" aria-hidden="true"></span><span class="panel-label">Legend</span></a> -->
+          <!--       <a class="panel-close" role="button" data-toggle="collapse" tabindex="0" href="#panelLegend"><span class="esri-icon esri-icon-close" aria-hidden="true"></span></a> -->
+          <!--     </div> -->
+          <!--   </div> -->
+          <!--   <div id="collapseLegend" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingLegend"> -->
+          <!--     <div class="panel-body"> -->
+          <!--       <div id="legendDiv"></div> -->
+          <!--     </div> -->
+          <!--   </div> -->
+          <!-- </div> -->
+          <!-- </div> -->
+
+          <!-- Result Panel -->
+          <div id="panelResult" class="panel collapse">
+            <div id="headingResult" class="panel-heading" role="tab">
+              <div class="panel-title">
+                <a class="panel-toggle" role="button" data-toggle="collapse" href="#collapseResult" aria-expanded="false" aria-controls="collapseLegend"><span class="glyphicon glyphicon-list-alt" aria-hidden="true"></span><span class="panel-label">Result</span></a>
+                <a class="panel-close" role="button" data-toggle="collapse" tabindex="0" href="#panelResult"><span class="esri-icon esri-icon-close" aria-hidden="true"></span></a>
+              </div>
+            </div>
+            <div id="collapseResult" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingResult">
+              <div class="panel-body">
+                <div id="resultDiv"></div>
+              </div>
+            </div>
+          </div>
         </div>
+
+        <script type="text/javascript">
+          var dojoConfig = {
+            packages: [{
+              name: "bootstrap",
+              location: "https://esri.github.io/calcite-maps/dist/vendor/dojo-bootstrap"
+            },
+            {
+              name: "calcite-maps",
+              location: "https://esri.github.io/calcite-maps/dist/js/dojo"
+            }]
+          };
+        </script>
+
+        <!-- ArcGIS JS 4 -->
+        <script src="https://js.arcgis.com/4.6/"></script>
+
+        <script>
+          require([
+            // ArcGIS
+            'esri/Map',
+            'esri/WebMap',
+            'esri/views/MapView',
+
+            // Widgets
+            // TODO: Remove what we don't use...
+            'esri/widgets/Home',
+            'esri/widgets/Zoom',
+            'esri/widgets/Compass',
+            'esri/widgets/Search',
+            'esri/widgets/Legend',
+            'esri/widgets/BasemapToggle',
+            'esri/widgets/ScaleBar',
+            'esri/widgets/Attribution',
+
+            // Tasks
+            'esri/tasks/IdentifyTask',
+            'esri/tasks/support/IdentifyParameters',
+
+            // Bootstrap
+            'bootstrap/Collapse',
+            'bootstrap/Dropdown',
+
+            // Calcite Maps
+            'calcite-maps/calcitemaps-v0.7',
+            // Calcite Maps ArcGIS Support
+            'calcite-maps/calcitemaps-arcgis-support-v0.7',
+
+            'dojo/domReady!',
+          ], function(
+            Map,
+            WebMap,
+            MapView,
+            Home,
+            Zoom,
+            Compass,
+            Search,
+            Legend,
+            BasemapToggle,
+            ScaleBar,
+            Attribution,
+            IdentifyTask,
+            IdentifyParameters,
+            Collapse,
+            Dropdown,
+            CalciteMaps,
+            CalciteMapArcGISSupport
+          ) {
+            var identifyTask, params;
+
+            // TODO: Can we get this URL from the map or the layer's ArcGIS content ID?
+            var drainageAreasUrl =
+              'https://watersgeo.epa.gov/arcgis/rest/services/NHDPlus_NP21/Catchments_NP21_Simplified/MapServer';
+
+            // Map
+            var map = new WebMap({
+              portalItem: {
+                // id: '9f91f911f58540ceaac0300c55e18fbb', // Just a random map for testing
+                id: '505bc0a0a0cf450e9b40658672ce16be',
+              },
+            });
+
+            // View
+            var mapView = new MapView({
+              container: 'mapViewDiv',
+              map: map,
+              padding: {
+                // Use the same value as #header-img height
+                top: 395,
+                bottom: 10,
+                right: 10,
+                left: 10,
+              },
+              ui: { components: [] },
+            });
+
+            mapView.when(function() {
+              console.log('when!');
+              // Create an identify task to locate boundaries
+              identifyTask = new IdentifyTask(drainageAreasUrl);
+              params = new IdentifyParameters();
+              params.tolerance = 1;
+              params.layerIds = [0]; // This map service's layer is found by ID
+              params.layerOption = 'top';
+              params.width = mapView.width;
+              params.height = mapView.height;
+            });
+
+            // Popup and panel sync
+            mapView.when(function() {
+              CalciteMapArcGISSupport.setPopupPanelSync(mapView);
+            });
+
+            var searchWidget = new Search({
+              container: 'searchWidgetDiv',
+              view: mapView,
+              // allPlaceholder: 'Find an address or place',
+              locationEnabled: true,
+              maxSuggestions: 3,
+              minSuggestCharacters: 2,
+              maxResults: 1,
+              searchAllEnabled: false,
+            });
+            // CalciteMapArcGISSupport.setSearchExpandEvents(searchWidget);
+
+            searchWidget.on('search-clear', function(event) {
+              console.log('Search input textbox was cleared.');
+            });
+
+            searchWidget.on('search-complete', function(event) {
+              // The results are stored in the event Object[]
+              console.log('Results of the search: ', event);
+              if (event.results) {
+                var result = event.results[0].results[0];
+                console.log('Name: ', result.name);
+                console.log('Location: ', result.feature);
+
+                // Set the geocode result as input to our Identity Task
+                params.geometry = result.feature.geometry;
+                params.mapExtent = mapView.extent; // TODO: Expand the search!
+
+                // TODO: Show a wait cursor or spinner
+                // dom.byId('mapViewDiv').style.cursor = 'wait';
+
+                // This function returns a promise that resolves to an array of features
+                identifyTask
+                  .execute(params)
+                  .then(function(response) {
+                    var results = response.results;
+                    if (results[0]) {
+                      var drainageArea = results[0];
+                      var feature = drainageArea.feature;
+                      var layerName = drainageArea.layerName;
+                      feature.attributes.layerName = layerName;
+                      feature.popupTemplate = {
+                        // autocasts as new PopupTemplate()
+                        title: 'Title 123',
+                        content: 'Content 345',
+                      };
+                      return feature;
+                    }
+
+                    // return arrayUtils.map(results, function(result) {
+                    //   var feature = result.feature;
+                    //   var layerName = result.layerName;
+                    //   feature.attributes.layerName = layerName;
+                    //   if (layerName === 'Soil Survey Geographic') {
+                    //     feature.popupTemplate = { // autocasts as new PopupTemplate()
+                    //       title: "{Map Unit Name}",
+                    //       content: "<b>Dominant order:</b> {Dominant Order} ({Dom. Cond. Order %}%)" +
+                    //         "<br><b>Farmland Class:</b> {Farmland Class}"
+                    //     };
+                    //   }
+                    //   return feature;
+                    // });
+                  })
+                  .then(showPopup);
+
+                // Shows the results of the Identify in a popup once the promise is resolved
+                function showPopup(feature) {
+                  if (feature) {
+                    mapView.popup.open({
+                      features: [feature],
+                      location: mapView.center, // TODO: use correct location
+                    });
+                  }
+                  // TODO: Disable the wait cursor and/or spinner
+                  // dom.byId('mapViewDiv').style.cursor = 'auto';
+                }
+              }
+            });
+            // Map widgets
+            // var home = new Home({
+            //   view: mapView
+            // });
+            // mapView.ui.add(home, "top-left");
+
+            var zoom = new Zoom({
+              view: mapView,
+            });
+            mapView.ui.add(zoom, 'bottom-left');
+
+            // var compass = new Compass({
+            //   view: mapView
+            // });
+            // mapView.ui.add(compass, "top-left");
+
+            var basemapToggle = new BasemapToggle({
+              view: mapView,
+              nextBasemap: 'satellite',
+              // nextBasemap: "streets-relief-vector"
+            });
+            mapView.ui.add(basemapToggle, 'bottom-right');
+
+            // var scaleBar = new ScaleBar({
+            //   view: mapView
+            // });
+            // mapView.ui.add(scaleBar, "bottom-left");
+
+            var attribution = new Attribution({
+              view: mapView,
+            });
+            mapView.ui.add(attribution, 'manual');
+
+            // Panel widgets - add legend
+            // var legendWidget = new Legend({
+            //   container: 'legendDiv',
+            //   view: mapView,
+            // });
+          });
+        </script>
+
+        <!-- <div class="col-md"> -->
+        <!--   <div id="waterway-info"></div> -->
+        <!-- </div> -->
+        <!-- <div class="col-md"> -->
+        <!--     <div id="map"></div> -->
+        <!-- </div> -->
       </div>
     </div>
 
     <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
-    <script src="https://js.arcgis.com/4.6/"></script>
-    <script src="main.js"></script>
+    <!-- <script src="main.js"></script> -->
   </body>
 </html>

--- a/main.css
+++ b/main.css
@@ -1,19 +1,37 @@
+html,
+body,
+#mapViewDiv {
+  padding: 0;
+  margin: 0;
+  height: 100%;
+  width: 100%;
+}
+
 body {
   font-family: 'EB Garamond', serif;
 }
 
-#map {
-  padding: 0;
-  margin: 0;
-  height: 500px;
+#heading-img {
+  z-index: 2;
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
   width: 100%;
-}
-.main-heading {
-  margin: 0.5em;
+  /* height: 395px; */
 }
 
-#heading-img {
-  width: 100%;
+#call-to-action {
+  position: relative;
+  top: 420px;
+  z-index: 3;
+}
+
+#searchWidgetDiv {
+}
+
+.main-heading {
+  margin: 0.5em;
 }
 
 ul {
@@ -28,4 +46,13 @@ ul {
   .main-heading {
     font-size: 2em;
   }
+}
+
+.esri-popup .esri-popup-header .esri-title {
+  font-size: 18px;
+  font-weight: bolder;
+}
+
+.esri-popup .esri-popup-body .esri-popup-content {
+  font-size: 14px;
 }

--- a/main.js
+++ b/main.js
@@ -1,182 +1,192 @@
-var MainMapView = null;
-$('[data-toggle="tooltip"]').tooltip();
-$('#map').hide();
+//var mapView = null;
+//$('[data-toggle="tooltip"]').tooltip();
+//$('#map').hide();
 
-require([
-  'esri/views/MapView',
-  'esri/WebMap',
-  // 'esri/tasks/IdentifyTask', // TODO: remove?
-  // 'esri/tasks/support/IdentifyParameters', // TODO: remove?
-  'dojo/domReady!',
-], function(MapView, /* IdentifyTask, IdentifyParameters, */ WebMap) {
-  /************************************************************
-   * Creates a new WebMap instance. A WebMap must reference
-   * a PortalItem ID that represents a WebMap saved to
-   * arcgis.com or an on-premise portal.
-   *
-   * To load a WebMap from an on-premise portal, set the portal
-   * url with esriConfig.portalUrl.
-   ************************************************************/
-  var webmap = new WebMap({
-    portalItem: {
-      // id: 'c13022a5c4754b958d3af300b2f0afc3',
-      id: '505bc0a0a0cf450e9b40658672ce16be',
-    },
-  });
+//require([
+//  'esri/views/MapView',
+//  'esri/WebMap',
+//  // 'esri/tasks/IdentifyTask', // TODO: remove?
+//  // 'esri/tasks/support/IdentifyParameters', // TODO: remove?
+//  // 'esri/widgets/BasemapToggle',
+//  'dojo/domReady!',
+//], function(
+//  MapView,
+//  /* IdentifyTask, IdentifyParameters, */ BasemapToggle,
+//  WebMap
+//) {
+//  /************************************************************
+//   * Creates a new WebMap instance. A WebMap must reference
+//   * a PortalItem ID that represents a WebMap saved to
+//   * arcgis.com or an on-premise portal.
+//   *
+//   * To load a WebMap from an on-premise portal, set the portal
+//   * url with esriConfig.portalUrl.
+//   ************************************************************/
+//  var webmap = new WebMap({
+//    portalItem: {
+//      // id: 'c13022a5c4754b958d3af300b2f0afc3',
+//      id: '505bc0a0a0cf450e9b40658672ce16be',
+//    },
+//  });
 
-  /************************************************************
-   * Set the WebMap instance to the map property in a MapView.
-   ************************************************************/
-  MainMapView = new MapView({
-    map: webmap,
-    container: 'map',
-    center: [-86.75, 36.16],
-    zoom: 12,
-  });
+//  /************************************************************
+//   * Set the WebMap instance to the map property in a MapView.
+//   ************************************************************/
+//  mapView = new MapView({
+//    map: webmap,
+//    container: 'map',
+//    center: [-86.75, 36.16], // Nashville, TN
+//    zoom: 11,
+//  });
 
-  // MainMapView.when(function() {
-  //   console.log('when!');
-  //   // Layers are indexed by position
-  //   // var myLayer = MainMapView.layers.getItemAt(1);
-  //   // MainMapView.whenLayerView(myLayer).then(function(lyrView) {
-  //   //   console.log('layer found!');
-  //   // });
-  // });
-});
+//  // var toggle = new BasemapToggle({
+//  //   view: mapView,
+//  //   nextBasemap: "hybrid" // allows for toggling to the 'hybrid' basemap
+//  // });
 
-function getLatLongFromAddress() {
-  addressData = {
-    singleLine: $('#AddressInput').val(),
-    outFields: 'Match_addr,Addr_type',
-  };
-  jQuery.ajax({
-    url:
-      'https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates?f=json',
-    type: 'POST',
-    data: addressData,
-    dataType: 'json',
-    beforeSend: function(x) {
-      if (x && x.overrideMimeType) {
-        x.overrideMimeType('application/j-son;charset=UTF-8');
-      }
-    },
-    success: function(result) {
-      var addressLatLongs = document.getElementById('retrivedCoOrdinates');
-      require(['esri/views/MapView', 'esri/WebMap', 'dojo/domReady!'], function(
-        MapView,
-        WebMap
-      ) {
-        var topHit = result.candidates[0];
-        MainMapView.goTo([
-          Number(topHit.location.x),
-          Number(topHit.location.y),
-        ]);
-        // .then(
-        //   // TODO: Create a point graphic (aka "marker) to show the geocode result.
-        //   function() {
-        //     console.log('then!');
-        //   }
-        // );
-      });
+//  // mapView.ui.add(toggle, "top-right");
 
-      //Show information and map
-      showWaterwayInfoAndMap();
-    },
-  });
-}
+//  // mapView.when(function() {
+//  //   console.log('when!');
+//  //   // Layers are indexed by position
+//  //   // var myLayer = mapView.layers.getItemAt(1);
+//  //   // mapView.whenLayerView(myLayer).then(function(lyrView) {
+//  //   //   console.log('layer found!');
+//  //   // });
+//  // });
+//});
 
-function getAddressFromBrowserLocation() {
-  if (navigator.geolocation) {
-    navigator.geolocation.getCurrentPosition(
-      getAddressFromBrowserLocationSucess,
-      onFail,
-      { enableHighAccuracy: true, timeout: 20000 }
-    );
-  } else {
-    x.innerHTML = 'Geolocation is not supported by this browser.';
-  }
-}
+//function getLatLongFromAddress() {
+//  addressData = {
+//    singleLine: $('#AddressInput').val(),
+//    outFields: 'Match_addr,Addr_type',
+//  };
+//  jQuery.ajax({
+//    url:
+//      'https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates?f=json',
+//    type: 'POST',
+//    data: addressData,
+//    dataType: 'json',
+//    beforeSend: function(x) {
+//      if (x && x.overrideMimeType) {
+//        x.overrideMimeType('application/j-son;charset=UTF-8');
+//      }
+//    },
+//    success: function(result) {
+//      var addressLatLongs = document.getElementById('retrivedCoOrdinates');
+//      require(['esri/views/MapView', 'esri/WebMap', 'dojo/domReady!'], function(
+//        MapView,
+//        WebMap
+//      ) {
+//        var topHit = result.candidates[0];
+//        mapView.goTo([
+//          Number(topHit.location.x),
+//          Number(topHit.location.y),
+//        ]);
+//        // .then(
+//        //   // TODO: Create a point graphic (aka "marker) to show the geocode result.
+//        //   function() {
+//        //     console.log('then!');
+//        //   }
+//        // );
+//      });
 
-function onFail() {
-  console.log('Error: unable to get geolocation');
-}
+//      //Show information and map
+//      showWaterwayInfoAndMap();
+//    },
+//  });
+//}
 
-function getAddressFromBrowserLocationSucess(position) {
-  console.log('test');
+//function getAddressFromBrowserLocation() {
+//  if (navigator.geolocation) {
+//    navigator.geolocation.getCurrentPosition(
+//      getAddressFromBrowserLocationSucess,
+//      onFail,
+//      { enableHighAccuracy: true, timeout: 20000 }
+//    );
+//  } else {
+//    x.innerHTML = 'Geolocation is not supported by this browser.';
+//  }
+//}
 
-  addressData = {
-    location: position.coords.longitude + ',' + position.coords.latitude,
-    outFields: 'Match_addr,Addr_type',
-  };
-  jQuery.ajax({
-    url:
-      'https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode?f=json',
-    type: 'POST',
-    data: addressData,
-    dataType: 'json',
-    beforeSend: function(x) {
-      if (x && x.overrideMimeType) {
-        x.overrideMimeType('application/j-son;charset=UTF-8');
-      }
-    },
-    success: function(result) {
-      $('#AddressInput').val(result.address.Match_addr);
-      MainMapView.goTo([Number(result.location.x), Number(result.location.y)]);
-      // .then(
-      //   // TODO: Create a point graphic (aka "marker) to show the geocode result.
-      //   function() {
-      //     console.log('then!');
-      //   }
-      // );
-      //Show information and map
-      showWaterwayInfoAndMap();
-    },
-  });
-}
+//function onFail() {
+//  console.log('Error: unable to get geolocation');
+//}
 
-function showWaterwayInfoAndMap() {
-  const waterwayInfoDomRef = document.getElementById('waterway-info');
-  let waterwayInformationHtmlTemplate = `<div class="card-body">
-  <div class="waterway-heading">
-    <h5 class="text-muted">Waterway Nearest This Address</h5>
-    <h3 class="card-title">Browns Creek</h3>
-  </div>
+//function getAddressFromBrowserLocationSucess(position) {
+//  addressData = {
+//    location: position.coords.longitude + ',' + position.coords.latitude,
+//    outFields: 'Match_addr,Addr_type',
+//  };
+//  jQuery.ajax({
+//    url:
+//      'https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode?f=json',
+//    type: 'POST',
+//    data: addressData,
+//    dataType: 'json',
+//    beforeSend: function(x) {
+//      if (x && x.overrideMimeType) {
+//        x.overrideMimeType('application/j-son;charset=UTF-8');
+//      }
+//    },
+//    success: function(result) {
+//      $('#AddressInput').val(result.address.Match_addr);
+//      mapView.goTo([Number(result.location.x), Number(result.location.y)]);
+//      // .then(
+//      //   // TODO: Create a point graphic (aka "marker) to show the geocode result.
+//      //   function() {
+//      //     console.log('then!');
+//      //   }
+//      // );
+//      //Show information and map
+//      showWaterwayInfoAndMap();
+//    },
+//  });
+//}
 
-  <div class="waterway-health text-danger">
-    <p class="font-weight-bold">Status: <span id="waterway-status">Unhealthy</span></p>
-  </div>
+//function showWaterwayInfoAndMap() {
+//  const waterwayInfoDomRef = document.getElementById('waterway-info');
+//  let waterwayInformationHtmlTemplate = `<div class="card-body">
+//  <div class="waterway-heading">
+//    <h5 class="text-muted">Waterway Nearest This Address</h5>
+//    <h3 class="card-title">Browns Creek</h3>
+//  </div>
 
-  <div class="waterway-problems">
-    <p>Select a problem to see how you can help this stream:</p>
-    <ul id="waterway-problems-list">
-      <li><a href="#">Pathogens</a></li>
-      <li><a href="#">Nutrients</a></li>
-      <li><a href="#"></a></li>
-    </ul>
+//  <div class="waterway-health text-danger">
+//    <p class="font-weight-bold">Status: <span id="waterway-status">Unhealthy</span></p>
+//  </div>
 
-  </div>
+//  <div class="waterway-problems">
+//    <p>Select a problem to see how you can help this stream:</p>
+//    <ul id="waterway-problems-list">
+//      <li><a href="#">Pathogens</a></li>
+//      <li><a href="#">Nutrients</a></li>
+//      <li><a href="#"></a></li>
+//    </ul>
 
-  <div class="waterway-adopt">
-    <h6 class="font-weight-bold">Adopt a Waterway</h6>
-    <p>
-      Are you a member of a group or organization in your community that would be interested in adopting this waterway?
-      <a href="#">Learn more...</a>
-    </p>
+//  </div>
 
-  </div>
+//  <div class="waterway-adopt">
+//    <h6 class="font-weight-bold">Adopt a Waterway</h6>
+//    <p>
+//      Are you a member of a group or organization in your community that would be interested in adopting this waterway?
+//      <a href="#">Learn more...</a>
+//    </p>
 
-  <div class="waterway-nearby">
-    <h6 class="font-weight-bold">Adjacent Waterways</h6>
-    <p>Check the health of these waterways near this address:</p>
-    <ul id="neighbor-waterways-list">
-      <li><a href="#">Check Upstream Water Health</a></li>
-      <li><a href="#">Check Downstream Water Health</a></li>
-    </ul>
-  </div>
+//  </div>
 
-  </div>`;
+//  <div class="waterway-nearby">
+//    <h6 class="font-weight-bold">Adjacent Waterways</h6>
+//    <p>Check the health of these waterways near this address:</p>
+//    <ul id="neighbor-waterways-list">
+//      <li><a href="#">Check Upstream Water Health</a></li>
+//      <li><a href="#">Check Downstream Water Health</a></li>
+//    </ul>
+//  </div>
 
-  console.log(waterwayInfoDomRef);
-  waterwayInfoDomRef.innerHTML = waterwayInformationHtmlTemplate;
-  $('#map').show();
-}
+//  </div>`;
+
+//  console.log(waterwayInfoDomRef);
+//  waterwayInfoDomRef.innerHTML = waterwayInformationHtmlTemplate;
+//  $('#map').show();
+//}


### PR DESCRIPTION
This is a big change.

Most of the code is based on samples at https://github.com/Esri/calcite-maps - I used Calcite demos to solve problems with our existing code base, e.g. 'Map is not ready' errors. Calcite also gives us a framework to add widgets and panels.

Finally, searches are now done with the `Search` widget from Esri's JS API. This gives us autocomplete and some other goodness, but the styling needs work.